### PR TITLE
Add an option to use jnumpy's experimental fast init mode which uses custom sysimage includes TyPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ pip install -U tyjuliacall
 ```python
 from tyjuliasetup import use_sysimage  # CAUTIOUS: not 'tyjuliacall'!
 use_sysimage(r"/path/to/sysimg")
+# if your sysimage contains TyPython,
+# you could call use_systemTyPython() to reduce the time cost of setting up julia.
 from tyjuliacall import Base
 print(
     "current sysimage in use",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -U tyjuliacall
 from tyjuliasetup import use_sysimage  # CAUTIOUS: not 'tyjuliacall'!
 use_sysimage(r"/path/to/sysimg")
 # if your sysimage contains TyPython,
-# you could call use_systemTyPython() to reduce the time cost of setting up julia.
+# you could call use_systemtypython() to reduce the time cost of setting up julia.
 from tyjuliacall import Base
 print(
     "current sysimage in use",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -U tyjuliacall
 from tyjuliasetup import use_sysimage  # CAUTIOUS: not 'tyjuliacall'!
 use_sysimage(r"/path/to/sysimg")
 # if your sysimage contains TyPython,
-# you could call use_systemtypython() to reduce the time cost of setting up julia.
+# you could call use_system_typython() to reduce the time cost of setting up julia.
 from tyjuliacall import Base
 print(
     "current sysimage in use",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tyjuliacall"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Python package for Tongyuan-hacked PyCall as an engineerization for Python-Julia interops."
 authors = ["Suzhou-Tongyuan <support@tongyuan.cc>"]
 packages = [
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-julia-numpy = "^0.3.0"
+julia-numpy = "^0.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tyjuliasetup/__init__.py
+++ b/tyjuliasetup/__init__.py
@@ -81,6 +81,7 @@ class ENV:
     JULIA_CONDAPKG_BACKEND: str
     PYTHON_JULIAPKG_OFFLINE: str
     PYTHON_JULIACALL_SYSIMAGE: str
+    USE_SYSTEM_TYPYTHON: str
 
     def __init__(self, env=None):
         self._env = env
@@ -164,6 +165,12 @@ def use_sysimage(path: str | pathlib.Path):
         path = pathlib.Path(path)
     Environment.TYPY_JL_SYSIMAGE = path.absolute().as_posix()
 
+def use_systemTyPython(yes: bool=True):
+    if yes:
+        Environment.USE_SYSTEM_TYPYTHON = "True"
+    else:
+        Environment.USE_SYSTEM_TYPYTHON = ""
+
 
 class _JuliaCodeEvaluatorClass:
     _eval_func: typing.Any
@@ -226,7 +233,10 @@ def setup():
     Environment.JULIA_PYTHONCALL_EXE = "@PyCall"
     Environment.PYTHON_JULIACALL_SYSIMAGE = BASE_IMAGE
 
-    jnumpy.init_jl()
+    if Environment.USE_SYSTEM_TYPYTHON:
+        jnumpy.init_jl(experimental_fast_init=True)
+    else:
+        jnumpy.init_jl()
     jnumpy.init_project(__file__)
     jnumpy.exec_julia("Pkg.activate(io=devnull)")
     import _tyjuliacall_jnumpy  # type: ignore

--- a/tyjuliasetup/__init__.py
+++ b/tyjuliasetup/__init__.py
@@ -165,7 +165,7 @@ def use_sysimage(path: str | pathlib.Path):
         path = pathlib.Path(path)
     Environment.TYPY_JL_SYSIMAGE = path.absolute().as_posix()
 
-def use_systemTyPython(yes: bool=True):
+def use_systemtypython(yes: bool=True):
     if yes:
         Environment.USE_SYSTEM_TYPYTHON = "True"
     else:

--- a/tyjuliasetup/__init__.py
+++ b/tyjuliasetup/__init__.py
@@ -165,7 +165,7 @@ def use_sysimage(path: str | pathlib.Path):
         path = pathlib.Path(path)
     Environment.TYPY_JL_SYSIMAGE = path.absolute().as_posix()
 
-def use_systemtypython(yes: bool=True):
+def use_system_typython(yes: bool=True):
     if yes:
         Environment.USE_SYSTEM_TYPYTHON = "True"
     else:


### PR DESCRIPTION
After https://github.com/Suzhou-Tongyuan/jnumpy/pull/61 merged, we could initialize julia if using custom image which includes TyPython package. This could reduce the time cost in setup julia if using a large sysimage.