### PR TITLE
fix ipython crash problem when getattr with module

### DIFF
--- a/tyjuliasetup/__init__.py
+++ b/tyjuliasetup/__init__.py
@@ -158,7 +158,11 @@ class JuliaModule(ModuleType):
         self.__spec__ = None
 
     def __getattr__(self, name):
-        return getattr(self.__it, name)
+        try:
+            att = getattr(self.__it, name)
+        except:
+            raise AttributeError(f"{self.__it} has no attribute {name}.") from None
+        return att
 
     def __dir__(self):
         return list(self._jlapi.Main.names(self.__it, all=True, imported=True))


### PR DESCRIPTION
start with ipython, then `from tyjuliacall import Main`， then throw a error

```
...
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\site-packages\IPython\core\ultratb.py", line 1101, in get_records
    return _fixed_getinnerframes(etb, number_of_lines_of_context, tb_offset)
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\site-packages\IPython\core\ultratb.py", line 248, in wrapped   
    return f(*args, **kwargs)
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\site-packages\IPython\core\ultratb.py", line 281, in _fixed_getinnerframes
    records = fix_frame_records_filenames(inspect.getinnerframes(etb, context))
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\inspect.py", line 1502, in getinnerframes
    frameinfo = (tb.tb_frame,) + getframeinfo(tb, context)
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\inspect.py", line 1460, in getframeinfo
    filename = getsourcefile(frame) or getfile(frame)
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\inspect.py", line 696, in getsourcefile
    if getattr(getmodule(object, filename), '__loader__', None) is not None:
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\inspect.py", line 733, in getmodule
    if ismodule(module) and hasattr(module, '__file__'):
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\site-packages\tyjuliasetup\__init__.py", line 160, in __getattr__
    return getattr(self.__it, name)
  File "C:\Users\Public\TongYuan\.julia\miniforge3\lib\site-packages\tyjuliasetup\jv.py", line 46, in __getattr__     
    return __jl_getattr__(self, name)
NameError: UndefVarError: `__file__` not defined
...
```